### PR TITLE
Drop sgratzl from auto PR assignments

### DIFF
--- a/.github/workflows/update_gdocs_data.yml
+++ b/.github/workflows/update_gdocs_data.yml
@@ -29,7 +29,7 @@ jobs:
           commit-message: 'chore: update docs'
           title: Update Google Docs Meta Data
           labels: chore
-          reviewers: krivard,sgratzl
-          assignees: sgratzl
+          reviewers: krivard
+          assignees: krivard
           body: |
             Updating Google Docs Meta Data


### PR DESCRIPTION


**Prerequisites**:

- [x] Unless it is a hotfix it should be merged against the `dev` branch
- [x] Branch is up-to-date with the branch to be merged with, i.e. `dev`
- [x] Build is successful
- [x] Code is cleaned up and formatted

### Summary

sam was still listed as assignee for updating the google docs data -- this is no longer necessary.
